### PR TITLE
87 make build scripts for webcomponents throw error

### DIFF
--- a/am-ui/build_scripts/package-webcomponents.js
+++ b/am-ui/build_scripts/package-webcomponents.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const resolve = require('path').resolve;
 const join = require('path').join;
-const cp = require('child_process');
+const spawn = require('child_process').spawn;
 const os = require('os');
 
 // get library path
@@ -19,9 +19,19 @@ fs.readdirSync(path).forEach(function (mod) {
   const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm';
 
   // install folder
-  cp.spawn(npmCmd, ['run', 'package', '--ignore-scripts'], {
+  const cp = spawn(npmCmd, ['run', 'package', '--ignore-scripts'], {
     env: process.env,
     cwd: modPath,
     stdio: 'inherit',
+  });
+  cp.on('exit', (code, signal) => {
+    if (code) {
+      console.error('Child exited with code', code);
+      throw new Error(code);
+    } else if (signal) {
+      console.error('Child was killed with signal', signal);
+    } else {
+      console.log('Child exited okay');
+    }
   });
 });

--- a/am-ui/webcomponents/build_scripts/build-webcomponents.js
+++ b/am-ui/webcomponents/build_scripts/build-webcomponents.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const resolve = require('path').resolve;
 const join = require('path').join;
-const cp = require('child_process');
+const spawn = require('child_process').spawn;
 const os = require('os');
 
 // get library path
@@ -18,18 +18,29 @@ fs.readdirSync(path).forEach(function (mod) {
   // npm binary based on OS
   const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm';
   const isProduction = process.argv[2] === '--prod';
+  let cp;
 
   if (isProduction) {
-    cp.spawn(npmCmd, ['run', 'build:prod'], {
+    cp = spawn(npmCmd, ['run', 'build:prod'], {
       env: process.env,
       cwd: modPath,
       stdio: 'inherit',
     });
   } else {
-    cp.spawn(npmCmd, ['run', 'build'], {
+    cp = spawn(npmCmd, ['run', 'build'], {
       env: process.env,
       cwd: modPath,
       stdio: 'inherit',
     });
   }
+  cp.on('exit', (code, signal) => {
+    if (code) {
+      console.error('Child exited with code', code);
+      throw new Error(code);
+    } else if (signal) {
+      console.error('Child was killed with signal', signal);
+    } else {
+      console.log('Child exited okay');
+    }
+  });
 });

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -1,63 +1,63 @@
 <script setup>
-import ApiClient from '../api/src/ApiClient';
-import CategoriesApi from '../api/src/api/CategoriesApi';
-import TopicsApi from '../api/src/api/TopicsApi';
-import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO';
-import {onMounted, ref, computed, watchEffect} from 'vue';
-import CreateAdFields from './CreateAdFields.vue';
-import {useI18n} from 'vue-i18n';
+import ApiClient from '../api/src/ApiClient'
+import CategoriesApi from '../api/src/api/CategoriesApi'
+import TopicsApi from '../api/src/api/TopicsApi'
+import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO'
+import {onMounted, ref, computed, watchEffect} from 'vue'
+import CreateAdFields from './CreateAdFields.vue'
+import {useI18n} from 'vue-i18n'
 
-const apiClient = new ApiClient('/');
-const categoriesApi = new CategoriesApi(apiClient);
-const topicsApi = new TopicsApi(apiClient);
-const categories = ref([]);
-const selectedCategoryKey = ref('');
-const requestOrOffer = ref('offer');
-const fieldsToShow = ref([]);
-const showAdFields = ref(false);
-let currentCategoryId = 0;
+const apiClient = new ApiClient('/')
+const categoriesApi = new CategoriesApi(apiClient)
+const topicsApi = new TopicsApi(apiClient)
+const categories = ref([])
+const selectedCategoryKey = ref('')
+const requestOrOffer = ref('offer')
+const fieldsToShow = ref([])
+const showAdFields = ref(false)
+let currentCategoryId = 0
 const props = defineProps({
   appLanguage: {
     default: 'de',
     type: String,
   },
-};
-const {t} = useI18n({useScope: 'global'});
+})
+const {t} = useI18n({useScope: 'global'})
 
 onMounted(() => {
-  categoriesApi.categoriesCreateGet(true, getCategories);
-});
+  categoriesApi.categoriesCreateGet(true, getCategories)
+})
 
-function getCategories(_error, data, _response) {
-  categories.value = data.categories;
-  updateFields();
+function getCategories (_error, data, _response) {
+  categories.value = data.categories
+  updateFields()
 }
 
-function updateFields() {
+function updateFields () {
   const selectedCategory = categories.value.find(
-    (category) => category.key === selectedCategoryKey.value,
-  );
+    category => category.key === selectedCategoryKey.value
+  )
   if (selectedCategory && selectedCategory.fields.length > 0) {
-    fieldsToShow.value = selectedCategory.fields;
-    showAdFields.value = true;
-    currentCategoryId = selectedCategory.category_id;
+    fieldsToShow.value = selectedCategory.fields
+    showAdFields.value = true
+    currentCategoryId = selectedCategory.category_id
   } else {
-    showAdFields.value = false;
+    showAdFields.value = false
   }
-};
+}
 
 // ignore
-function submit(data) {
+function submit (data) {
   const dto = new TopicSaveRequestDTO(
-      0,
-      currentCategoryId,
-      requestOrOffer.value.toUpperCase(),
-      data,
-  );
-  topicsApi.topicsPost(dto);
+    0,
+    currentCategoryId,
+    requestOrOffer.value.toUpperCase(),
+    data
+  )
+  topicsApi.topicsPost(dto)
 }
 
-defineExpose({ updateFields })
+defineExpose({updateFields})
 </script>
 
 <template>

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -1,63 +1,63 @@
 <script setup>
-import ApiClient from '../api/src/ApiClient'
-import CategoriesApi from '../api/src/api/CategoriesApi'
-import TopicsApi from '../api/src/api/TopicsApi'
-import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO'
-import {onMounted, ref, computed, watchEffect} from 'vue'
-import CreateAdFields from './CreateAdFields.vue'
-import {useI18n} from 'vue-i18n'
+import ApiClient from '../api/src/ApiClient';
+import CategoriesApi from '../api/src/api/CategoriesApi';
+import TopicsApi from '../api/src/api/TopicsApi';
+import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO';
+import {onMounted, ref, computed, watchEffect} from 'vue';
+import CreateAdFields from './CreateAdFields.vue';
+import {useI18n} from 'vue-i18n';
 
-const apiClient = new ApiClient('/')
-const categoriesApi = new CategoriesApi(apiClient)
-const topicsApi = new TopicsApi(apiClient)
-const categories = ref([])
-const selectedCategoryKey = ref('')
-const requestOrOffer = ref('offer')
-const fieldsToShow = ref([])
-const showAdFields = ref(false)
-let currentCategoryId = 0
+const apiClient = new ApiClient('/');
+const categoriesApi = new CategoriesApi(apiClient);
+const topicsApi = new TopicsApi(apiClient);
+const categories = ref([]);
+const selectedCategoryKey = ref('');
+const requestOrOffer = ref('offer');
+const fieldsToShow = ref([]);
+const showAdFields = ref(false);
+let currentCategoryId = 0;
 const props = defineProps({
   appLanguage: {
     default: 'de',
     type: String,
   },
-})
-const {t} = useI18n({useScope: 'global'})
+});
+const {t} = useI18n({useScope: 'global'});
 
 onMounted(() => {
-  categoriesApi.categoriesCreateGet(true, getCategories)
-})
+  categoriesApi.categoriesCreateGet(true, getCategories);
+});
 
-function getCategories (_error, data, _response) {
-  categories.value = data.categories
-  updateFields()
+function getCategories(_error, data, _response) {
+  categories.value = data.categories;
+  updateFields();
 }
 
-function updateFields () {
+function updateFields() {
   const selectedCategory = categories.value.find(
-    category => category.key === selectedCategoryKey.value
-  )
+      (category) => category.key === selectedCategoryKey.value,
+  );
   if (selectedCategory && selectedCategory.fields.length > 0) {
-    fieldsToShow.value = selectedCategory.fields
-    showAdFields.value = true
-    currentCategoryId = selectedCategory.category_id
+    fieldsToShow.value = selectedCategory.fields;
+    showAdFields.value = true;
+    currentCategoryId = selectedCategory.category_id;
   } else {
-    showAdFields.value = false
+    showAdFields.value = false;
   }
 }
 
 // ignore
-function submit (data) {
+function submit(data) {
   const dto = new TopicSaveRequestDTO(
-    0,
-    currentCategoryId,
-    requestOrOffer.value.toUpperCase(),
-    data
-  )
-  topicsApi.topicsPost(dto)
+      0,
+      currentCategoryId,
+      requestOrOffer.value.toUpperCase(),
+      data,
+  );
+  topicsApi.topicsPost(dto);
 }
 
-defineExpose({updateFields})
+defineExpose({updateFields});
 </script>
 
 <template>

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -1,63 +1,63 @@
 <script setup>
-import ApiClient from '../api/src/ApiClient';
-import CategoriesApi from '../api/src/api/CategoriesApi';
-import TopicsApi from '../api/src/api/TopicsApi';
-import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO';
-import {onMounted, ref, computed, watchEffect} from 'vue';
-import CreateAdFields from './CreateAdFields.vue';
-import {useI18n} from 'vue-i18n';
+import ApiClient from '../api/src/ApiClient'
+import CategoriesApi from '../api/src/api/CategoriesApi'
+import TopicsApi from '../api/src/api/TopicsApi'
+import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO'
+import {onMounted, ref, computed, watchEffect} from 'vue'
+import CreateAdFields from './CreateAdFields.vue'
+import {useI18n} from 'vue-i18n'
 
-const apiClient = new ApiClient('/');
-const categoriesApi = new CategoriesApi(apiClient);
-const topicsApi = new TopicsApi(apiClient);
-const categories = ref([]);
-const selectedCategoryKey = ref('');
-const requestOrOffer = ref('offer');
-const fieldsToShow = ref([]);
-const showAdFields = ref(false);
-let currentCategoryId = 0;
+const apiClient = new ApiClient('/')
+const categoriesApi = new CategoriesApi(apiClient)
+const topicsApi = new TopicsApi(apiClient)
+const categories = ref([])
+const selectedCategoryKey = ref('')
+const requestOrOffer = ref('offer')
+const fieldsToShow = ref([])
+const showAdFields = ref(false)
+let currentCategoryId = 0
 const props = defineProps({
   appLanguage: {
     default: 'de',
     type: String,
   },
-});
-const {t} = useI18n({useScope: 'global'});
+})
+const {t} = useI18n({useScope: 'global'})
 
 onMounted(() => {
-  categoriesApi.categoriesCreateGet(true, getCategories);
-});
+  categoriesApi.categoriesCreateGet(true, getCategories)
+})
 
-function getCategories(_error, data, _response) {
-  categories.value = data.categories;
-  updateFields();
+function getCategories (_error, data, _response) {
+  categories.value = data.categories
+  updateFields()
 }
 
-function updateFields() {
+function updateFields () {
   const selectedCategory = categories.value.find(
-      (category) => category.key === selectedCategoryKey.value,
-  );
+    category => category.key === selectedCategoryKey.value
+  )
   if (selectedCategory && selectedCategory.fields.length > 0) {
-    fieldsToShow.value = selectedCategory.fields;
-    showAdFields.value = true;
-    currentCategoryId = selectedCategory.category_id;
+    fieldsToShow.value = selectedCategory.fields
+    showAdFields.value = true
+    currentCategoryId = selectedCategory.category_id
   } else {
-    showAdFields.value = false;
+    showAdFields.value = false
   }
 }
 
 // ignore
-function submit(data) {
+function submit (data) {
   const dto = new TopicSaveRequestDTO(
-      0,
-      currentCategoryId,
-      requestOrOffer.value.toUpperCase(),
-      data,
-  );
-  topicsApi.topicsPost(dto);
+    0,
+    currentCategoryId,
+    requestOrOffer.value.toUpperCase(),
+    data
+  )
+  topicsApi.topicsPost(dto)
 }
 
-defineExpose({updateFields});
+defineExpose({updateFields})
 </script>
 
 <template>

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -1,63 +1,63 @@
 <script setup>
-import ApiClient from '../api/src/ApiClient'
-import CategoriesApi from '../api/src/api/CategoriesApi'
-import TopicsApi from '../api/src/api/TopicsApi'
-import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO'
-import {onMounted, ref, computed, watchEffect} from 'vue'
-import CreateAdFields from './CreateAdFields.vue'
-import {useI18n} from 'vue-i18n'
+import ApiClient from '../api/src/ApiClient';
+import CategoriesApi from '../api/src/api/CategoriesApi';
+import TopicsApi from '../api/src/api/TopicsApi';
+import TopicSaveRequestDTO from '../api/src/model/TopicSaveRequestDTO';
+import {onMounted, ref, computed, watchEffect} from 'vue';
+import CreateAdFields from './CreateAdFields.vue';
+import {useI18n} from 'vue-i18n';
 
-const apiClient = new ApiClient('/')
-const categoriesApi = new CategoriesApi(apiClient)
-const topicsApi = new TopicsApi(apiClient)
-const categories = ref([])
-const selectedCategoryKey = ref('')
-const requestOrOffer = ref('offer')
-const fieldsToShow = ref([])
-const showAdFields = ref(false)
-let currentCategoryId = 0
+const apiClient = new ApiClient('/');
+const categoriesApi = new CategoriesApi(apiClient);
+const topicsApi = new TopicsApi(apiClient);
+const categories = ref([]);
+const selectedCategoryKey = ref('');
+const requestOrOffer = ref('offer');
+const fieldsToShow = ref([]);
+const showAdFields = ref(false);
+let currentCategoryId = 0;
 const props = defineProps({
   appLanguage: {
     default: 'de',
     type: String,
   },
-})
-const {t} = useI18n({useScope: 'global'})
+};
+const {t} = useI18n({useScope: 'global'});
 
 onMounted(() => {
-  categoriesApi.categoriesCreateGet(true, getCategories)
-})
+  categoriesApi.categoriesCreateGet(true, getCategories);
+});
 
-function getCategories (_error, data, _response) {
-  categories.value = data.categories
-  updateFields()
+function getCategories(_error, data, _response) {
+  categories.value = data.categories;
+  updateFields();
 }
 
-function updateFields () {
+function updateFields() {
   const selectedCategory = categories.value.find(
-    category => category.key === selectedCategoryKey.value
-  )
+    (category) => category.key === selectedCategoryKey.value,
+  );
   if (selectedCategory && selectedCategory.fields.length > 0) {
-    fieldsToShow.value = selectedCategory.fields
-    showAdFields.value = true
-    currentCategoryId = selectedCategory.category_id
+    fieldsToShow.value = selectedCategory.fields;
+    showAdFields.value = true;
+    currentCategoryId = selectedCategory.category_id;
   } else {
-    showAdFields.value = false
+    showAdFields.value = false;
   }
-}
+};
 
 // ignore
-function submit (data) {
+function submit(data) {
   const dto = new TopicSaveRequestDTO(
-    0,
-    currentCategoryId,
-    requestOrOffer.value.toUpperCase(),
-    data
-  )
-  topicsApi.topicsPost(dto)
+      0,
+      currentCategoryId,
+      requestOrOffer.value.toUpperCase(),
+      data,
+  );
+  topicsApi.topicsPost(dto);
 }
 
-defineExpose({updateFields})
+defineExpose({ updateFields })
 </script>
 
 <template>

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -21,7 +21,7 @@ const props = defineProps({
     default: 'de',
     type: String,
   },
-});
+};
 const {t} = useI18n({useScope: 'global'});
 
 onMounted(() => {
@@ -58,7 +58,6 @@ function submit(data) {
 }
 
 defineExpose({ updateFields })
-
 </script>
 
 <template>

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAd.ce.vue
@@ -21,7 +21,7 @@ const props = defineProps({
     default: 'de',
     type: String,
   },
-};
+});
 const {t} = useI18n({useScope: 'global'});
 
 onMounted(() => {
@@ -58,6 +58,7 @@ function submit(data) {
 }
 
 defineExpose({ updateFields })
+
 </script>
 
 <template>


### PR DESCRIPTION
This PR adds an exit listener on the build and package scripts that checks for error codes and throws errors if there are any, resulting in visible errors in the build process.