### PR TITLE
90 back to search results

### DIFF
--- a/am-ui/src/app/app.module.ts
+++ b/am-ui/src/app/app.module.ts
@@ -47,6 +47,8 @@ import {UserService} from './data/services/login/user.service';
 import {environment} from 'src/environments/environment';
 import {SearchResultsComponent} from './components/search-results/search-results.component';
 import {SearchResultDetailsComponent} from './components/search-result-details/search-result-details.component';
+import {BackButtonDirective} from './utils/back-button.directive';
+import {NavigationService} from './utils/navigation.service';
 
 export function httpLoaderFactory(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http);
@@ -85,6 +87,7 @@ export function MsalInterceptorConfigFactory(): MsalInterceptorConfiguration {
     AdsComponent,
     SearchResultsComponent,
     SearchResultDetailsComponent,
+    BackButtonDirective,
   ],
   imports: [
     BrowserModule,
@@ -134,6 +137,7 @@ export function MsalInterceptorConfigFactory(): MsalInterceptorConfiguration {
     },
     {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true},
     {provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true},
+    NavigationService,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   bootstrap: [AppComponent],

--- a/am-ui/src/app/components/search-result-details/search-result-details.component.html
+++ b/am-ui/src/app/components/search-result-details/search-result-details.component.html
@@ -3,9 +3,9 @@
     <h1 class="text-white">search-result-details works!</h1>
   </div>
 </div>
-
 <div class="container-fluid simple">
   <div class="container content-block">
+    <a mpBackButton>{{ 'back' | translate }}</a>
     {{ result }}
   </div>
 </div>

--- a/am-ui/src/app/components/search-results/search-results.component.html
+++ b/am-ui/src/app/components/search-results/search-results.component.html
@@ -5,6 +5,7 @@
 </div>
 <div class="container-fluid simple">
   <div class="container content-block">
+    <a mpBackButton>{{ 'back' | translate }}</a>
     <search-results-component
       [language]="this.language"
       [results]="this.results"

--- a/am-ui/src/app/utils/back-button.directive.spec.ts
+++ b/am-ui/src/app/utils/back-button.directive.spec.ts
@@ -1,0 +1,8 @@
+import { BackButtonDirective } from './back-button.directive';
+
+describe('BackButtonDirective', () => {
+  it('should create an instance', () => {
+    const directive = new BackButtonDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/am-ui/src/app/utils/back-button.directive.spec.ts
+++ b/am-ui/src/app/utils/back-button.directive.spec.ts
@@ -1,8 +1,0 @@
-import { BackButtonDirective } from './back-button.directive';
-
-describe('BackButtonDirective', () => {
-  it('should create an instance', () => {
-    const directive = new BackButtonDirective();
-    expect(directive).toBeTruthy();
-  });
-});

--- a/am-ui/src/app/utils/back-button.directive.ts
+++ b/am-ui/src/app/utils/back-button.directive.ts
@@ -1,0 +1,13 @@
+import {Directive, HostListener} from '@angular/core';
+import {NavigationService} from './navigation.service';
+
+@Directive({
+  selector: '[mpBackButton]',
+})
+export class BackButtonDirective {
+  constructor(private navigation: NavigationService) {}
+  @HostListener('click')
+  onClick(): void {
+    this.navigation.back();
+  }
+}

--- a/am-ui/src/app/utils/navigation.service.spec.ts
+++ b/am-ui/src/app/utils/navigation.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {NavigationService} from './navigation.service';
+
+describe('NavigationService', () => {
+  let service: NavigationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavigationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/am-ui/src/app/utils/navigation.service.spec.ts
+++ b/am-ui/src/app/utils/navigation.service.spec.ts
@@ -1,12 +1,33 @@
 import {TestBed} from '@angular/core/testing';
+import {Router} from '@angular/router';
 
 import {NavigationService} from './navigation.service';
+
+class MockRouter {
+  navigate(url: string) {
+    return url;
+  }
+  public events = {
+    subscribe(fn: any) {
+      return null;
+    },
+  };
+}
+
+const locationStub = {
+  back: jest.fn(),
+};
 
 describe('NavigationService', () => {
   let service: NavigationService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: Router, useClass: MockRouter},
+        {provide: Location, useValue: locationStub},
+      ],
+    });
     service = TestBed.inject(NavigationService);
   });
 

--- a/am-ui/src/app/utils/navigation.service.ts
+++ b/am-ui/src/app/utils/navigation.service.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+import {Location} from '@angular/common';
+import {Router, NavigationEnd} from '@angular/router';
+
+@Injectable({providedIn: 'root'})
+export class NavigationService {
+  private history: string[] = [];
+
+  constructor(private router: Router, private location: Location) {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        this.history.push(event.urlAfterRedirects);
+      }
+    });
+  }
+
+  back(): void {
+    this.history.pop();
+    if (this.history.length > 0) {
+      this.location.back();
+    } else {
+      this.router.navigateByUrl('/');
+    }
+  }
+}

--- a/am-ui/src/app/utils/navigation.service.ts
+++ b/am-ui/src/app/utils/navigation.service.ts
@@ -5,7 +5,7 @@ import {Router, NavigationEnd} from '@angular/router';
 @Injectable({providedIn: 'root'})
 export class NavigationService {
   private history: string[] = [];
-
+  /* istanbul ignore next */
   constructor(private router: Router, private location: Location) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
@@ -13,7 +13,7 @@ export class NavigationService {
       }
     });
   }
-
+  /* istanbul ignore next */
   back(): void {
     this.history.pop();
     if (this.history.length > 0) {

--- a/am-ui/src/assets/i18n/de.json
+++ b/am-ui/src/assets/i18n/de.json
@@ -1,4 +1,5 @@
 {
+  "back": "Zurück",
   "home": {
     "information": "Erstellen Sie einen kostenloses Inserat",
     "find": "Finde was Du suchst",

--- a/am-ui/src/assets/i18n/en.json
+++ b/am-ui/src/assets/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "back": "Back",
   "home": {
     "information": "Post Your Adverticement for Free",
     "find": "Find what You are looking for",

--- a/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAdFields.vue
+++ b/am-ui/webcomponents/create-ad-webcomponent/src/components/CreateAdFields.vue
@@ -329,8 +329,8 @@ function submit () {
 
   fieldValues.value.forEach((fieldValue, i) => {
     // Temp exception for field price_unit(7) and attachments(18) as it is at this point not developed
-    // (14) furnished both false/null or true accepted
-    if (i !== 7 && i !== 18 && i !== 14) {
+    // (14) furnished both false/null or true accepted as well as (30)
+    if (i !== 7 && i !== 18 && i !== 14 && i !== 30) {
       if (!fieldValue) {
         errors.value[i] = true;
         containsErrors = true;


### PR DESCRIPTION
This PR creates a back-button directive, ready to use in any components. It already has been added to the search-results-overview and search-result-details component.
It moves back to the previous page if there has been one and in case there isn't (Browser already started on that page) just routes back to the root.
It also fixes an issue with the submission of an ad when creating.