### PR TITLE
Disable unused field "Radius (KM)" from the search form

### DIFF
--- a/marketplace-service/src/main/resources/liquibase/changelogs/V0_002_creation_fields_changes.yml
+++ b/marketplace-service/src/main/resources/liquibase/changelogs/V0_002_creation_fields_changes.yml
@@ -562,3 +562,20 @@ databaseChangeLog:
                   name: field_id
                   valueNumeric: 34
             tableName: subcategory_field
+  - changeSet:
+      id: V0.002/9
+      author: asiday
+      comment: Remove fields for parking
+      changes:
+        - delete:
+            tableName: subcategory_field
+            where: subcategory_id=1 AND field_id=34
+        - delete:
+            tableName: subcategory_field
+            where: subcategory_id=2 AND field_id=34
+        - delete:
+            tableName: subcategory_field
+            where: subcategory_id=3 AND field_id=34
+        - delete:
+            tableName: subcategory_field
+            where: subcategory_id=4 AND field_id=34


### PR DESCRIPTION
Changes:
- Create a "ChangeSet" in configuration resource file to delete Radius field from the table subcategory_field.

Close #172